### PR TITLE
Add NetBSD support

### DIFF
--- a/nitroctl.c
+++ b/nitroctl.c
@@ -257,7 +257,7 @@ normalize(char *service)
 
 	char *buf = realpath(service, 0);
 	if (!buf) {
-		fprintf(stderr, "nitroctl: no such service: %s: %m\n", service);
+		fprintf(stderr, "nitroctl: no such service: %s: %s\n", service, strerror(errno));
 		exit(1);
 	}
 


### PR DESCRIPTION
These patches bring support to NetBSD, first by fixing non portable `%m` format, then by adding memory filesystem mount of `/var/run` so `nitro` can create the necessary directories for the control socket.  
After applying these patches I was able to boot a NetBSD virtual machine with `nitro` as its `init(8)`.

Tested on NetBSD, Linux and FreeBSD.